### PR TITLE
ownership/permission behaviour tweaks

### DIFF
--- a/setgitperms.perl
+++ b/setgitperms.perl
@@ -74,7 +74,7 @@ if ( $write_mode ) {
 
     chomp;
 
-    if ( /^(.*)  mode=(\S+)\s+uid=(\w+)\s+gid=(\w+)/ ) {
+    if ( /^(.*)  mode=(\S+)\s+uid=([\w.-]+)\s+gid=([\w.-]+)/ ) {
 
       # Compare recorded perms to actual perms in the working dir
       my ( $path, $mode, $uid, $gid ) = ( $1, $2, $3, $4 );

--- a/setgitperms.perl
+++ b/setgitperms.perl
@@ -78,6 +78,8 @@ if ( $write_mode ) {
 
       # Compare recorded perms to actual perms in the working dir
       my ( $path, $mode, $uid, $gid ) = ( $1, $2, $3, $4 );
+      $uid =~ /^\d+$/ or $uid = getpwnam($uid);
+      $gid =~ /^\d+$/ or $gid = getgrnam($gid);
       my $fullpath = $topdir . $path;
       my ( undef, undef, $wmode, undef, $wuid, $wgid ) = lstat( $fullpath );
       $wmode = sprintf "%04o", $wmode & 07777;

--- a/setgitperms.perl
+++ b/setgitperms.perl
@@ -37,6 +37,7 @@ info for all files/dirs tracked by git in the repository.
 -r,  --read         Reads perms/etc from working dir into a .gitmeta file
 -s,  --stdout       Output to stdout instead of .gitmeta
 -d,  --diff         Show unified diff of perms file (XOR with --stdout)
+-n,  --names        Use user/group names instead of numeric ids
 
 ---------------------------------Write Mode------------------------------------
 -w,  --write        Modify perms/etc in working dir to match the .gitmeta file
@@ -44,7 +45,7 @@ info for all files/dirs tracked by git in the repository.
 
 \n";
 
-my ( $stdout, $showdiff, $verbose, $read_mode, $write_mode );
+my ( $stdout, $showdiff, $verbose, $read_mode, $write_mode, $use_names );
 
 if ((@ARGV < 0) || !GetOptions(
 
@@ -53,6 +54,7 @@ if ((@ARGV < 0) || !GetOptions(
   "read",           \$read_mode,
   "write",          \$write_mode,
   "verbose",        \$verbose,
+  "names",          \$use_names,
 
 )) { die $usage; }
 
@@ -72,18 +74,13 @@ if ( $write_mode ) {
 
     chomp;
 
-    if ( /^(.*)  mode=(\S+)\s+uid=(\d+)\s+gid=(\d+)/ ) {
+    if ( /^(.*)  mode=(\S+)\s+uid=(\w+)\s+gid=(\w+)/ ) {
 
       # Compare recorded perms to actual perms in the working dir
       my ( $path, $mode, $uid, $gid ) = ( $1, $2, $3, $4 );
       my $fullpath = $topdir . $path;
       my ( undef, undef, $wmode, undef, $wuid, $wgid ) = lstat( $fullpath );
       $wmode = sprintf "%04o", $wmode & 07777;
-
-      if ( $mode ne $wmode ) {
-        $verbose && print "Updating permissions on $path: old=$wmode, new=$mode\n";
-        chmod oct( $mode ), $fullpath;
-      }
 
       if ( $uid != $wuid || $gid != $wgid ) {
         if ( $verbose ) {
@@ -103,6 +100,11 @@ if ( $write_mode ) {
 
         chown $uid, $gid, $fullpath;
 
+      }
+
+      if ( $mode ne $wmode ) {
+        $verbose && print "Updating permissions on $path: old=$wmode, new=$mode\n";
+        chmod oct( $mode ), $fullpath;
       }
     } else {
       warn "Invalid input format in $gitmeta:\n\t$_\n";
@@ -241,6 +243,10 @@ sub printstats {
   $path =~ s/@/\@/g;
   my ( undef, undef, $mode, undef, $uid, $gid ) = lstat( $path );
   $path =~ s/%/\%/g;
+  if ( $use_names ) {
+    $uid = getpwuid($uid);
+    $gid = getgrgid($gid);
+  }
 
   if ( $stdout ) {
     printf "%s  mode=%04o  uid=$uid  gid=$gid\n", $path, $mode & 07777;


### PR DESCRIPTION
- chown _then_ chmod. the other way round causes sticky bits to be lost.
- add a -n option to save symbolic user/group names instead of numeric ids
